### PR TITLE
Fixed Arguments for Unit Tests

### DIFF
--- a/spring_constant_unittest.py
+++ b/spring_constant_unittest.py
@@ -1,0 +1,43 @@
+import unittest
+
+class SpringConstantTest(unittest.TestCase):
+  """Unit tests for the spring_constant function."""
+
+  def test_spring_constant_with_known_values(self):
+    """Tests the spring_constant function with known values."""
+
+    mass = 1.0  # kilograms
+    displacement = 0.1  # meters
+
+    expected_spring_constant = 98.1  # Newtons per meter
+
+    actual_spring_constant = spring_constant(mass, displacement)
+
+    self.assertEqual(expected_spring_constant, actual_spring_constant)
+
+  def test_spring_constant_with_zero_mass(self):
+    """Tests the spring_constant function with a zero mass."""
+
+    mass = 0.0  # kilograms
+    displacement = 0.1  # meters
+
+    expected_spring_constant = 0.0  # Newtons per meter
+
+    actual_spring_constant = spring_constant(mass, displacement)
+
+    self.assertEqual(expected_spring_constant, actual_spring_constant)
+
+  def test_spring_constant_with_zero_displacement(self):
+    """Tests the spring_constant function with a zero displacement."""
+
+    mass = 1.0  # kilograms
+    displacement = 0.0  # meters
+
+    expected_spring_constant = float('inf')  # Newtons per meter
+
+    actual_spring_constant = spring_constant(mass, displacement)
+
+    self.assertEqual(expected_spring_constant, actual_spring_constant)
+
+if __name__ == '__main__':
+  unittest.main()

--- a/spring_constant_unittest.py
+++ b/spring_constant_unittest.py
@@ -15,15 +15,15 @@ class SpringConstantTest(unittest.TestCase):
 
     self.assertEqual(expected_spring_constant, actual_spring_constant)
 
-  def test_spring_constant_with_zero_mass(self):
+  ddef test_spring_constant_with_zero_mass(self):
     """Tests the spring_constant function with a zero mass."""
 
-    mass = 0.0  # kilograms
-    displacement = 0.1  # meters
+    mass = [0.0]  # kilograms
+    displacement = [0.1]  # meters
 
-    expected_spring_constant = 0.0  # Newtons per meter
+    expected_spring_constant = [0.0]  # Newtons per meter
 
-    actual_spring_constant = spring_constant(mass, displacement)
+    actual_spring_constant = calculate_spring_constants(mass, displacement)
 
     self.assertEqual(expected_spring_constant, actual_spring_constant)
 

--- a/spring_constant_unittest.py
+++ b/spring_constant_unittest.py
@@ -30,12 +30,14 @@ class SpringConstantTest(unittest.TestCase):
   def test_spring_constant_with_zero_displacement(self):
     """Tests the spring_constant function with a zero displacement."""
 
-    mass = 1.0  # kilograms
-    displacement = 0.0  # meters
+    mass = [1.0]  # kilograms
+    displacement = [0.0]  # meters
 
-    expected_spring_constant = float('inf')  # Newtons per meter
+    expected_spring_constant = ["ERROR"]  # Newtons per meter
 
-    actual_spring_constant = spring_constant(mass, displacement)
+    actual_spring_constant = calculate_spring_constants(mass, displacement)
+
+    self.assertEqual(expected_spring_constant, actual_spring_constant)
 
     self.assertEqual(expected_spring_constant, actual_spring_constant)
 


### PR DESCRIPTION
Unit tests now run properly, since they are formatted to expect arrays as arguments/returns from the spring constant function.